### PR TITLE
Have `UnsignedNumeric::new` not return an `Option`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These values are measured inside the Solana SVM (via test programs).
 use brine_fp::UnsignedNumeric;
 
 // Construct a fixed-point number: 5.0
-let five = UnsignedNumeric::new(5).unwrap();
+let five = UnsignedNumeric::new(5);
 
 // Compute its exponential
 let result = five.signed().exp().unwrap();

--- a/src/exp.rs
+++ b/src/exp.rs
@@ -235,57 +235,49 @@ mod tests {
         let half = UnsignedNumeric { value: half() }.signed();
         assert!(half.exp().unwrap().almost_eq(
             &UnsignedNumeric::new(16487212707001282)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(10000000000000000))
                 .unwrap(),
             precision
         ));
 
         let three_half = UnsignedNumeric::new(15)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(10).unwrap())
+            .checked_div(&UnsignedNumeric::new(10))
             .unwrap()
             .signed();
         assert!(three_half.exp().unwrap().almost_eq(
             &UnsignedNumeric::new(44816890703380645)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(10000000000000000))
                 .unwrap(),
             precision
         ));
 
         let point_one = UnsignedNumeric::new(1)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(10).unwrap())
+            .checked_div(&UnsignedNumeric::new(10))
             .unwrap()
             .signed();
         assert!(point_one.exp().unwrap().almost_eq(
             &UnsignedNumeric::new(11051709180756477)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(10000000000000000))
                 .unwrap(),
             precision
         ));
 
         let negative = UnsignedNumeric::new(55)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(100).unwrap())
+            .checked_div(&UnsignedNumeric::new(100))
             .unwrap()
             .signed()
             .negate();
         assert!(negative.exp().unwrap().almost_eq(
             &UnsignedNumeric::new(5769498103804866)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(10000000000000000))
                 .unwrap(),
             precision
         ));
 
-        let test = UnsignedNumeric::new(19).unwrap().signed();
+        let test = UnsignedNumeric::new(19).signed();
         assert!(test.exp().unwrap().almost_eq(
             &UnsignedNumeric::new(178482300963187260)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(1000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(1000000000))
                 .unwrap(),
             precision
         ));
@@ -294,24 +286,52 @@ mod tests {
     #[test]
     fn test_pow() {
         let precision = InnerUint::from(5_000_000_000_000_u128); // correct to at least 12 decimal places
-        let test = UnsignedNumeric::new(8).unwrap();
+        let test = UnsignedNumeric::new(8);
         let sqrt = test.pow(&HALF).unwrap();
         let expected = UnsignedNumeric::new(28284271247461903)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+            .checked_div(&UnsignedNumeric::new(10000000000000000))
             .unwrap();
         assert!(sqrt.almost_eq(&expected, precision));
 
         let test2 = UnsignedNumeric::new(55)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(100).unwrap())
+            .checked_div(&UnsignedNumeric::new(100))
             .unwrap();
         let squared = test2.pow(&TWO_PREC).unwrap();
         let expected = UnsignedNumeric::new(3025)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(10000).unwrap())
+            .checked_div(&UnsignedNumeric::new(10000))
             .unwrap();
         assert!(squared.almost_eq(&expected, precision));
+    }
+
+    #[test]
+    fn test_sqrt() {
+        let precision = InnerUint::from(5_000_000_000_000_u128); // correct to at least 12 decimal places
+        let test = UnsignedNumeric::new(12);
+        let sqrt = test.sqrt().unwrap();
+        let expected = UnsignedNumeric::new(34641016151377544)
+            .checked_div(&UnsignedNumeric::new(10000000000000000))
+            .unwrap();
+        assert!(sqrt.almost_eq(&expected, precision));
+    }
+
+    #[test]
+    pub fn test_signed_sqrt() {
+        let precision = InnerUint::from(5_000_000_000_000_u128); // correct to at least 12 decimal places
+        let test = SignedNumeric {
+            value: UnsignedNumeric::new(8),
+            is_negative: false,
+        };
+        let sqrt = test.sqrt().unwrap();
+        let expected = UnsignedNumeric::new(28284271247461903)
+            .checked_div(&UnsignedNumeric::new(10000000000000000))
+            .unwrap();
+        assert!(sqrt.value.almost_eq(&expected, precision));
+
+        let neg_test = SignedNumeric {
+            value: UnsignedNumeric::new(8),
+            is_negative: true,
+        };
+        assert!(neg_test.sqrt().is_none());
     }
 
     #[test]
@@ -324,8 +344,7 @@ mod tests {
     #[test]
     fn test_exp_small_negative() {
         let x = UnsignedNumeric::new(1)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(1000).unwrap())
+            .checked_div(&UnsignedNumeric::new(1000))
             .unwrap()
             .signed()
             .negate();
@@ -343,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_exp_large_positive() {
-        let x = UnsignedNumeric::new(10).unwrap().signed(); // e^10 ≈ 22026.4657948067
+        let x = UnsignedNumeric::new(10).signed(); // e^10 ≈ 22026.4657948067
         let result = x.exp().unwrap();
 
         // Correctly scaled expected value: e^10 * 1e18
@@ -358,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_exp_large_negative() {
-        let x = UnsignedNumeric::new(10).unwrap().signed().negate(); // e^-10 ≈ 0.00004539992
+        let x = UnsignedNumeric::new(10).signed().negate(); // e^-10 ≈ 0.00004539992
         let result = x.exp().unwrap();
 
         let expected = UnsignedNumeric::from_scaled_u128(45_399_920_000_000); // scaled by 10^18
@@ -398,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_frexp_two() {
-        let two = UnsignedNumeric::new(2).unwrap();
+        let two = UnsignedNumeric::new(2);
         let (frac, exp) = two.frexp().unwrap();
         let recombined = frexp_recombine(frac.clone(), exp);
         assert!(
@@ -415,8 +434,8 @@ mod tests {
 
     #[test]
     fn test_frexp_fractional() {
-        let val = UnsignedNumeric::new(3).unwrap()
-            .checked_div(&UnsignedNumeric::new(4).unwrap()) // 0.75
+        let val = UnsignedNumeric::new(3)
+            .checked_div(&UnsignedNumeric::new(4)) // 0.75
             .unwrap();
         let (frac, exp) = val.frexp().unwrap();
         let recombined = frexp_recombine(frac.clone(), exp);

--- a/src/log.rs
+++ b/src/log.rs
@@ -108,7 +108,7 @@ impl UnsignedNumeric {
         let s4 = s2.checked_mul(&s2)?;
         // s2 * (L1 + s4*(L3+s4*(L5+s4*L7)))
         let t1 = s2.checked_mul(&L1.checked_add(&s4.checked_mul(
-            &L3.checked_add(&s4.checked_mul(&L5.checked_add(&s4.checked_mul(&L7)?)?)?)?,
+            &L3.checked_add(&s4.checked_mul(&L5.checked_add(&s4.checked_mul(&L7)?)?)?)?
         )?)?)?;
 
         // s4 * (L2 + s4*(L4+s4*L6))
@@ -121,7 +121,7 @@ impl UnsignedNumeric {
             .checked_mul(&f)?
             .checked_div(&UnsignedNumeric { value: two() }.signed())?;
         let k = SignedNumeric {
-            value: UnsignedNumeric::new(u128::try_from(ki.abs()).ok()?)?,
+            value: UnsignedNumeric::new(u128::try_from(ki.abs()).ok()?),
             is_negative: ki < 0,
         };
 
@@ -152,55 +152,47 @@ mod tests {
     fn test_log() {
         let precision = InnerUint::from(5_000_000_000_u128); // correct to at least 9 decimal places
 
-        let test = UnsignedNumeric::new(9).unwrap();
+        let test = UnsignedNumeric::new(9);
         let log = test.log().unwrap().value;
         let expected = UnsignedNumeric::new(21972245773362196)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+            .checked_div(&UnsignedNumeric::new(10000000000000000))
             .unwrap();
         assert!(log.almost_eq(&expected, precision));
 
-        let test2 = UnsignedNumeric::new(2).unwrap();
+        let test2 = UnsignedNumeric::new(2);
         assert!(test2.log().unwrap().value.almost_eq(
             &UnsignedNumeric::new(6931471805599453)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(10000000000000000))
                 .unwrap(),
             precision
         ));
 
         let test3 = &UnsignedNumeric::new(12)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(10).unwrap())
+            .checked_div(&UnsignedNumeric::new(10))
             .unwrap();
         assert!(test3.log().unwrap().value.almost_eq(
             &UnsignedNumeric::new(1823215567939546)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(10000000000000000))
                 .unwrap(),
             precision
         ));
 
         let test5 = &UnsignedNumeric::new(15)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(10).unwrap())
+            .checked_div(&UnsignedNumeric::new(10))
             .unwrap();
         assert!(test5.log().unwrap().value.almost_eq(
             &UnsignedNumeric::new(4054651081081644)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(10000000000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(10000000000000000))
                 .unwrap(),
             precision
         ));
 
         let test6 = UnsignedNumeric::new(4)
-            .unwrap()
-            .checked_div(&UnsignedNumeric::new(1000000).unwrap())
+            .checked_div(&UnsignedNumeric::new(1000000))
             .unwrap();
         assert!(test6.log().unwrap().value.almost_eq(
             &UnsignedNumeric::new(12429216196844383)
-                .unwrap()
-                .checked_div(&UnsignedNumeric::new(1000000000000000).unwrap())
+                .checked_div(&UnsignedNumeric::new(1000000000000000))
                 .unwrap(),
             precision
         ));

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -32,6 +32,14 @@ pub struct SignedNumeric {
 }
 
 impl SignedNumeric {
+    pub fn new(value: i128) -> Self {
+        let abs_value = value.unsigned_abs();
+        let is_negative = value < 0;
+        Self {
+            value: UnsignedNumeric::new(abs_value),
+            is_negative,
+        }
+    }
     pub fn negate(&self) -> SignedNumeric {
         SignedNumeric {
             value: self.value.clone(),
@@ -116,7 +124,7 @@ mod tests {
 
     fn signed(val: u128, is_negative: bool) -> SignedNumeric {
         SignedNumeric {
-            value: UnsignedNumeric::new(val).unwrap(),
+            value: UnsignedNumeric::new(val),
             is_negative,
         }
     }


### PR DESCRIPTION
The precisions means that it'll never overflow

I cherry-picked this so it won't work unless you also merge `sqrt`